### PR TITLE
Allow server ops to silence DEBUG messages

### DIFF
--- a/lua/sgrf/config.lua
+++ b/lua/sgrf/config.lua
@@ -25,6 +25,11 @@ SGRF.Config.SteamGroup = 'CHANGE ME'
 -- You can get this at https://steamcommunity.com/dev/apikey.
 SGRF.Config.SteamAPIKey = 'CHANGE ME'
 
+--- Should DEBUG-level log messages be printed?
+-- You should really only set this to true if asked to by the developers. This will cause a lot of
+-- console spam.
+SGRF.Config.LogDebugMessages = false
+
 --[[-------------------------
        REWARDS SETTINGS
 

--- a/lua/sgrf/server/sv_functions.lua
+++ b/lua/sgrf/server/sv_functions.lua
@@ -163,6 +163,8 @@ end
 -- @param      _str     The string to write to the log
 -- @param[opt] ...      Anything to pass to string.format
 function SGRF.Log(channel, _str, ...)
+	if channel == "DEBUG" and not SGRF.Config.LogDebugMessages then return end
+
 	local str = _str
 	if ... then
 		if type(...) == 'table' then

--- a/lua/sgrf/server/sv_functions.lua
+++ b/lua/sgrf/server/sv_functions.lua
@@ -104,16 +104,16 @@ function SGRF.CheckPlayer(ply, callback)
 
 						-- This is nasty, yes. But it works!
 						SGRF.Log('DEBUG', 'Beginning body traversal...')
-						for _, child in pairs(doc.kids) do
-							SGRF.Log('DEBUG', '%d: %s (%s) encountered', _, child.name, child.type)
+						for k, child in pairs(doc.kids) do
+							SGRF.Log('DEBUG', '%d: %s (%s) encountered', k, child.name, child.type)
 							if child.type == 'element' and child.name == 'memberList' then -- root element
 								SGRF.Log('DEBUG', 'Found root element')
-								for __, child2 in pairs(child.el) do
-									SGRF.Log('DEBUG', '%d - %d: %s (%s) encountered', _, __, child2.name, child2.type) -- shut up about my code pyramids glualint :(
+								for k2, child2 in pairs(child.el) do
+									SGRF.Log('DEBUG', '%d - %d: %s (%s) encountered', k, k2, child2.name, child2.type) -- shut up about my code pyramids glualint :(
 									if child2.name == 'members' then -- members list
 										SGRF.Log('DEBUG', 'Found members element')
-										for ___, member in pairs(child2.el) do
-											SGRF.Log('DEBUG', '%d - %d - %d: %s (%s) encountered', _, __, ___, member.name, member.type)
+										for k3, member in pairs(child2.el) do
+											SGRF.Log('DEBUG', '%d - %d - %d: %s (%s) encountered', k, k2, k3, member.name, member.type)
 											if member.name == 'steamID64' then
 												SGRF.Log('DEBUG', 'Found steamID64 element with value %s', el.value)
 

--- a/lua/sgrf/server/sv_functions.lua
+++ b/lua/sgrf/server/sv_functions.lua
@@ -163,7 +163,7 @@ end
 -- @param      _str     The string to write to the log
 -- @param[opt] ...      Anything to pass to string.format
 function SGRF.Log(channel, _str, ...)
-	if channel == "DEBUG" and not SGRF.Config.LogDebugMessages then return end
+	if channel == 'DEBUG' and not SGRF.Config.LogDebugMessages then return end
 
 	local str = _str
 	if ... then


### PR DESCRIPTION
Should cut down on the amount of console spam we generate. A good portion of `SGRF.Log` calls are there purely to help us out, and aren't very useful for server operators.